### PR TITLE
Fix compilation error on Ubuntu 16.04

### DIFF
--- a/src/fusion/definitions.h
+++ b/src/fusion/definitions.h
@@ -8,7 +8,7 @@
 #ifndef DEFINITIONS_H_
 #define DEFINITIONS_H_
 
-
+#include <limits>
 #define UNENDLICH std::numeric_limits<float>::infinity()
 
 //#define CRAPPY_LAPPY

--- a/src/onlinefusionviewer.cpp
+++ b/src/onlinefusionviewer.cpp
@@ -6,6 +6,7 @@
  */
 #include <GL/glew.h>
 #include "onlinefusionviewer.hpp"
+#include <QGLViewer/manipulatedFrame.h>
 #include <math.h>
 #include <QMenu>
 #include <QKeyEvent>


### PR DESCRIPTION
When building on Ubuntu 16.04 I receive the following error "error: 'numeric_limits' is not a meber of 'std'" 

Including limits here fixes the compilation issue.

Also fixes the  "forward declaration of ‘struct qglviewer::ManipulatedFrame’" build error by including QGLViewer/manipulatedFrame.h
